### PR TITLE
release: build nessarary executable with 5 core compoent with `-DLLVM_INSTALL_UTILS=OFF`

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -90,7 +90,7 @@ get_base_cmake_args() {
 -DLLVM_INCLUDE_BENCHMARKS=OFF
 -DLLVM_BUILD_DOCS=OFF
 -DLLVM_ENABLE_DOXYGEN=OFF
--DLLVM_INSTALL_UTILS=ON
+-DLLVM_INSTALL_UTILS=OFF
 -DLLVM_ENABLE_Z3_SOLVER=OFF
 -DLLVM_ENABLE_LIBEDIT=OFF
 -DLLVM_OPTIMIZED_TABLEGEN=ON
@@ -276,7 +276,10 @@ build_platform() {
     echo "Building $target..."
     local cores=$(get_cpu_cores)
     echo "Using $cores CPU cores for build"
-    ninja -j"$cores"
+
+    # Build only essential tools to significantly reduce build time
+    # LLGo currently only requires libLLVM.dylib for dynamic libraries, and this dylib will be built with the following targets
+    ninja -j"$cores" clang llvm-config llvm-ar llvm-nm lld
 
     # Install
     echo "Installing $target..."


### PR DESCRIPTION
part of https://github.com/goplus/espressif-llvm-project-prebuilt/issues/12

Optimize LLVM Build Time by Targeting Essential Tools Only

Problem:
Current build compiles all 123 LLVM tools, taking >2 hours(macos x86) and often exceeding CI/Homebrew timeout limits.

Solution:
Build only the 5 essential tools required by LLGO: clang, lld, llvm-ar, llvm-nm, and llvm-config. This approach is inspired by TinyGo's optimization strategy.

Impact:
- Full functionality preserved: All LLGo requirements met
- Dynamic library support: libLLVM.dylib automatically built with these targets
- CI/Homebrew compatible: Fits within timeout constraints

LLGO only requires libLLVM.dylib for CGO bindings, making the other 118 tools unnecessary for core functionality.