### PR TITLE
ci:build llvm with linux/arm with older glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         # Install newer CMake (LLVM requires 3.20+, Ubuntu 20.04 has 3.16)
         CMAKE_VERSION="3.25.3"
         CMAKE_ARCH="x86_64"
-        if [[ "${{ matrix.target }}" == "aarch64-linux-gnu" ]]; then
+        if [ "${{ matrix.target }}" = "aarch64-linux-gnu" ]; then
           CMAKE_ARCH="aarch64"
         fi
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           - target: aarch64-linux-gnu
             os: ubuntu-22.04-arm
             runner: ubuntu-22.04-arm
+            container: ubuntu:20.04
 
           # macOS x86_64 build
           - target: x86_64-apple-darwin
@@ -119,14 +120,19 @@ jobs:
         
         # Install newer CMake (LLVM requires 3.20+, Ubuntu 20.04 has 3.16)
         CMAKE_VERSION="3.25.3"
-        wget -O cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz"
+        CMAKE_ARCH="x86_64"
+        if [[ "${{ matrix.target }}" == "aarch64-linux-gnu" ]]; then
+          CMAKE_ARCH="aarch64"
+        fi
+        
+        wget -O cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz"
         tar -xzf cmake.tar.gz -C /opt
-        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin/* /usr/local/bin/
+        ln -sf /opt/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin/* /usr/local/bin/
         rm cmake.tar.gz
         cmake --version
 
     - name: Install build dependencies (Linux)
-      if: matrix.os == 'ubuntu-22.04-arm'
+      if: matrix.os == 'ubuntu-22.04-arm' && matrix.container != 'ubuntu:20.04'
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential cmake ninja-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,10 @@ jobs:
           CMAKE_ARCH="aarch64"
         fi
         
+        echo "Matrix target: ${{ matrix.target }}"
+        echo "CMAKE_ARCH: ${CMAKE_ARCH}"
+        echo "Download URL: https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz"
+        
         wget -O cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz"
         tar -xzf cmake.tar.gz -C /opt
         ln -sf /opt/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin/* /usr/local/bin/


### PR DESCRIPTION
parts of https://github.com/goplus/llgo/issues/1265

linux/arm64 ubuntu24 (in macos docker)
```bash
root@4daf8338e716:~/llgo/_demo/embed# /root/llgo/bin/esp-llgo build -target esp32 -o test.bin .
cross compile: crosscompile.Export{CC:"/root/llgo/crosscompile/clang/bin/clang++", CCFLAGS:[]string{"--target=xtensa", "-mcpu=esp32"}, CFLAGS:[]string{"-Wno-override-module", "-Qunused-arguments", "-Wno-unused-command-line-argument", "--target=xtensa", "-Werror", "-fshort-enums", "-Wno-macro-redefined", "-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables", "-ffunction-sections", "-fdata-sections", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib/libc/include", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib/libc"}, LDFLAGS:[]string{"-mllvm", "-mcpu=esp32", "-mllvm", "-mattr=+atomctl,+bool,+clamps,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+minmax,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed", "-T", "targets/esp32.memory.elf.ld", "-L", "/root/llgo", "-nostdlib", "-L/root/.cache/llgo/crosscompile/newlib-esp32", "-lcrt0-xtensa", "-lgloss-xtensa", "-lc-xtensa", "-nostdlib", "-L/root/.cache/llgo/crosscompile/compiler-rt", "-lclang_builtins-xtensa", "--gc-sections"}, BuildTags:[]string{"xtensa", "baremetal", "linux", "arm", "esp32", "esp"}, GOOS:"linux", GOARCH:"arm", Libc:"newlib-esp32", Linker:"/root/llgo/crosscompile/clang/bin/ld.lld", ExtraFiles:[]string(nil), ClangRoot:"/root/llgo/crosscompile/clang", ClangBinPath:"", BinaryFormat:"esp32", FormatDetail:""}
root@4daf8338e716:~/llgo/_demo/embed# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.2 LTS"
root@4daf8338e716:~/llgo/_demo/embed# uname -a
Linux 4daf8338e716 6.10.14-linuxkit #1 SMP Fri Nov 29 17:22:03 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux

root@4daf8338e716:~/llgo/_demo/embed# ldd --version
ldd (Ubuntu GLIBC 2.39-0ubuntu8.4) 2.39
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```

linux arm64 ubuntu20(in macos docker)

```bash
root@4b421695ff68:~/llgo# export CGO_ENABLED=1
root@4b421695ff68:~/llgo# export CGO_CXXFLAGS="-std=c++17"
root@4b421695ff68:~/llgo# export CGO_CPPFLAGS="-I/root/llgo/crosscompile/clang/include -I/root/llgo/crosscompile/clang/include/llvm -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
root@4b421695ff68:~/llgo# export CGO_LDFLAGS="-L/root/llgo/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib"
root@4b421695ff68:~/llgo# 
root@4b421695ff68:~/llgo# go build -o ./bin/esp-llgo -ldflags="-X github.com/goplus/llgo/internal/env.buildVersion=v1.0.0 -X github.com/goplus/llgo/internal/env.buildTime=2030.1.1 -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/root/llgo/crosscompile/clang/bin/llvm-config" ./cmd/llgo
root@4b421695ff68:~/llgo# ldd ./bin/esp-llgo 
        linux-vdso.so.1 (0x0000ffff83f9f000)
        libLLVM.so.19.1 => /root/llgo/./bin/../crosscompile/clang/lib/libLLVM.so.19.1 (0x0000ffff7e200000)
        libresolv.so.2 => /lib/aarch64-linux-gnu/libresolv.so.2 (0x0000ffff83f49000)
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff7e1cf000)
        libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffff7dfea000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffff83f25000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff7de77000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffff83f6f000)
        librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000ffff7de5f000)
        libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffff7de4b000)
        libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000ffff7de21000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff7dd76000)

root@4b421695ff68:~/llgo/_demo/emb# /root/llgo/bin/esp-llgo build -target esp32 -o test.bin .
cross compile: crosscompile.Export{CC:"/root/llgo/crosscompile/clang/bin/clang++", CCFLAGS:[]string{"--target=xtensa", "-mcpu=esp32"}, CFLAGS:[]string{"-Wno-override-module", "-Qunused-arguments", "-Wno-unused-command-line-argument", "--target=xtensa", "-Werror", "-fshort-enums", "-Wno-macro-redefined", "-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables", "-ffunction-sections", "-fdata-sections", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib/libc/include", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib", "-I/root/.cache/llgo/crosscompile/newlib-esp32/newlib/libc"}, LDFLAGS:[]string{"-mllvm", "-mcpu=esp32", "-mllvm", "-mattr=+atomctl,+bool,+clamps,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+minmax,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed", "-T", "targets/esp32.memory.elf.ld", "-L", "/root/llgo", "-nostdlib", "-L/root/.cache/llgo/crosscompile/newlib-esp32", "-lcrt0-xtensa", "-lgloss-xtensa", "-lc-xtensa", "-nostdlib", "-L/root/.cache/llgo/crosscompile/compiler-rt", "-lclang_builtins-xtensa", "--gc-sections"}, BuildTags:[]string{"xtensa", "baremetal", "linux", "arm", "esp32", "esp"}, GOOS:"linux", GOARCH:"arm", Libc:"newlib-esp32", Linker:"/root/llgo/crosscompile/clang/bin/ld.lld", ExtraFiles:[]string(nil), ClangRoot:"/root/llgo/crosscompile/clang", ClangBinPath:"", BinaryFormat:"esp32", FormatDetail:""}
```

----

this question is a older ubuntu20 to use llgo's question https://github.com/goplus/llgo/issues/1273
```bash
root@4b421695ff68:~/llgo/_demo/hello# /root/llgo/bin/esp-llgo run .
ld.lld: error: undefined symbol: dladdr
>>> referenced by debug.c
>>>               /root/.cache/go-build/f9/f9a4d45bae1330f42db27e5efbdaee11cf53c01d9be786b6ff70c562f91d9110-ddebug.c.o:(llgo_addrinfo)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
panic: exit status 1
```